### PR TITLE
move wall up for fetch navigation

### DIFF
--- a/fetchit_challenge/worlds/nec0115a_arena.world
+++ b/fetchit_challenge/worlds/nec0115a_arena.world
@@ -10,7 +10,7 @@
     <include>
       <uri>model://nec0115a_arena</uri>
       <name>nec0115a_arena</name>
-      <pose>0 0 0 0 0 0</pose>
+      <pose>0 0 0.24 0 0 0</pose>
     </include>
 
     <include>


### PR DESCRIPTION

closes TheRARELab/ar_physical_ros#46

Moved the wall up so that the fetch robot can sense it for navigation.

![image](https://github.com/user-attachments/assets/7d817b22-3be8-4c6f-9c34-6ecbe9d239ff)

